### PR TITLE
add basic logging support

### DIFF
--- a/TimesynqServer/Controllers/UserController.cs
+++ b/TimesynqServer/Controllers/UserController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using TimesynqServer.Database.Entities;
 using TimesynqServer.Extensions;
@@ -20,6 +20,7 @@ namespace TimesynqServer.Controllers
         }
 
         [HttpGet("me")]
+        [Authorize]
         public async Task<IActionResult> Me()
         {
             string? callerId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/TimesynqServer/Middleware/ExceptionsMiddleware.cs
+++ b/TimesynqServer/Middleware/ExceptionsMiddleware.cs
@@ -8,10 +8,12 @@ namespace TimesynqServer.Middleware
     {
 
         private readonly RequestDelegate _next;
+        private readonly ILogger<ExceptionsMiddleware> _logger;
 
-        public ExceptionsMiddleware(RequestDelegate next)
+        public ExceptionsMiddleware(RequestDelegate next, ILogger<ExceptionsMiddleware> logger)
         {
             _next = next;
+            _logger = logger;
         }
 
         public async Task InvokeAsync(HttpContext context)
@@ -22,7 +24,7 @@ namespace TimesynqServer.Middleware
             }
             catch (Exception ex) 
             {
-                //todo: log exception
+                _logger.LogError("Exception caught: {Exception}", ex.ToString());
 
                 var response = new ResponseDTO<object>
                 {

--- a/TimesynqServer/Middleware/LogAuthorizedUserIdMiddleware.cs
+++ b/TimesynqServer/Middleware/LogAuthorizedUserIdMiddleware.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
+
+namespace TimesynqServer.Middleware
+{
+    public class LogAuthorizedUserIdMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<LogAuthorizedUserIdMiddleware> _logger;
+
+        public LogAuthorizedUserIdMiddleware(RequestDelegate next, ILogger<LogAuthorizedUserIdMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            Endpoint? endpoint = context.GetEndpoint();
+            if (endpoint != null) 
+            {
+                IAuthorizeData? authorizeData = endpoint.Metadata.GetMetadata<IAuthorizeData>();
+                if (authorizeData != null)
+                {
+                    string? callerId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                    if (callerId.IsNullOrEmpty())
+                    {
+                        _logger.LogWarning("User with missing name identifier called endpoint {Endpoint}", endpoint.DisplayName);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("User {UserId} called endpoint {Endpoint}", callerId, endpoint.DisplayName);
+                    }
+                }
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/TimesynqServer/Program.cs
+++ b/TimesynqServer/Program.cs
@@ -2,17 +2,40 @@ using Amazon.SimpleEmail;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using System.Security.Claims;
+using Serilog;
+using Serilog.Sinks.OpenTelemetry;
 using TimesynqServer.Database;
 using TimesynqServer.Database.Entities;
 using TimesynqServer.Extensions;
 using TimesynqServer.Hubs.TrackerHub;
 using TimesynqServer.Middleware;
 using TimesynqServer.Services.Email;
+using TimesynqServer.Services.Logging;
 using TimesynqServer.Services.Repository.FollowRepository;
 using TimesynqServer.Services.Repository.UserRepository;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();
+SerilogOptions serilogOptions = builder.Configuration.GetSection(SerilogOptions.ConfigurationSection).Get<SerilogOptions>()!;
+Log.Logger = new LoggerConfiguration()
+    .Enrich.FromLogContext()
+    .WriteTo.OpenTelemetry(x =>
+    {
+        x.Endpoint = serilogOptions.Endpoint;
+        x.Protocol = OtlpProtocol.HttpProtobuf;
+        x.Headers = new Dictionary<string, string>
+        {
+            ["X-Seq-ApiKey"] = serilogOptions.ApiKey,
+        };
+        x.ResourceAttributes = new Dictionary<string, object>
+        {
+            ["service.name"] = serilogOptions.ServiceName,
+        };
+    })
+    .CreateLogger();
+
+builder.Services.AddSerilog();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -75,8 +98,9 @@ app.MapTimesynqIdentityApi<TimesynqUser>();
 
 app.MapHub<TrackerHub>("hub");
 
-app.MapGet("ping", () =>
+app.MapGet("ping", (ILogger<Program> logger) =>
 {
+    logger.LogInformation("pong");
     return "pong";
 });
 

--- a/TimesynqServer/Program.cs
+++ b/TimesynqServer/Program.cs
@@ -86,12 +86,13 @@ if (app.Environment.IsDevelopment())
     app.ApplyMigrations();
 }
 
-app.UseMiddleware<ExceptionsMiddleware>();
-
 app.UseHttpsRedirection();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseMiddleware<ExceptionsMiddleware>();
+app.UseMiddleware<LogAuthorizedUserIdMiddleware>();
 
 app.MapControllers();
 app.MapTimesynqIdentityApi<TimesynqUser>();

--- a/TimesynqServer/Services/Logging/SerilogOptions.cs
+++ b/TimesynqServer/Services/Logging/SerilogOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace TimesynqServer.Services.Logging
+{
+    public sealed class SerilogOptions
+    {
+        /// <summary>
+        /// The name of the configuration section used to bind <see cref="SerilogOptions"/>.
+        /// </summary>
+        public const string ConfigurationSection = nameof(SerilogOptions);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string ServiceName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Endpoint { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string ApiKey { get; set; } = string.Empty;
+    }
+}

--- a/TimesynqServer/TimesynqServer.csproj
+++ b/TimesynqServer/TimesynqServer.csproj
@@ -21,6 +21,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>

--- a/TimesynqServer/appsettings.Development.example.json
+++ b/TimesynqServer/appsettings.Development.example.json
@@ -7,7 +7,12 @@
     "Region": ""
   },
   "EmailSenderOptions": {
-    "FromEmail":  ""
+    "FromEmail": ""
+  },
+  "SerilogOptions": {
+    "ServiceName":  "",
+    "Endpoint": "",
+    "ApiKey": ""
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
add serilog -> seq with OpenTelemetry protocol
logs basic request metadata and exceptions
does not log every single step to avoid unnecessary clutter, does not log request bodies (for security)
we'll decide if we want these later 

Closes #9 