### PR TITLE
EmailNotConfirmedMiddleware, better queries, Swagger response schema

### DIFF
--- a/TimesynqServer/Controllers/FollowController.cs
+++ b/TimesynqServer/Controllers/FollowController.cs
@@ -109,7 +109,7 @@ namespace TimesynqServer.Controllers
                 return ErrorResponse(StatusCodes.Status409Conflict, "Can't follow yourself");
             }
 
-            TimesynqUser? followee = await _userRepository.GetById(followRequest.FolloweeGuid);
+            TimesynqUser? followee = await _userRepository.GetByIdAsync(followRequest.FolloweeGuid);
             if (followee == null)
             {
                 return ErrorResponse(StatusCodes.Status404NotFound, "Followee doesn't exist");

--- a/TimesynqServer/Controllers/FollowController.cs
+++ b/TimesynqServer/Controllers/FollowController.cs
@@ -26,6 +26,11 @@ namespace TimesynqServer.Controllers
 
         [HttpGet("{followeeGuid}")]
         [Authorize(Roles = "ConfirmedUser, Admin")]
+        [ProducesResponseType(typeof(ResponseDTO<FollowDTO>), StatusCodes.Status200OK)]
+        [ProducesErrorResponseType(typeof(ResponseDTO<object>))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetFollow(Guid followeeGuid)
         {
             string? callerId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -47,6 +52,7 @@ namespace TimesynqServer.Controllers
 
         [HttpGet("{userId}/followers")]
         [Authorize]
+        [ProducesResponseType(typeof(ResponseDTO<PagedResult<UserDTO>>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetFollowers(Guid userId, [FromQuery] int pageNumber = 1, [FromQuery] int pageSize = 50)
         {
             pageSize = Math.Clamp(pageSize, 1, 100);
@@ -71,6 +77,7 @@ namespace TimesynqServer.Controllers
 
         [HttpGet("{userId}/followees")]
         [Authorize]
+        [ProducesResponseType(typeof(ResponseDTO<PagedResult<UserDTO>>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetFollowees(Guid userId, [FromQuery] int pageNumber = 1, [FromQuery] int pageSize = 50)
         {
             pageSize = Math.Clamp(pageSize, 1, 100);
@@ -95,6 +102,12 @@ namespace TimesynqServer.Controllers
 
         [HttpPost]
         [Authorize(Roles = "ConfirmedUser, Admin")]
+        [ProducesResponseType(typeof(FollowDTO), StatusCodes.Status201Created)]
+        [ProducesErrorResponseType(typeof(ResponseDTO<object>))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> FollowUser([FromBody] FollowRequestDTO followRequest)
         {
             string? callerId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -130,6 +143,10 @@ namespace TimesynqServer.Controllers
 
         [HttpDelete]
         [Authorize(Roles = "ConfirmedUser, Admin")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesErrorResponseType(typeof(ResponseDTO<object>))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> UnfollowUser([FromBody] UnfollowRequestDTO unfollowRequest)
         {
             string? callerId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/TimesynqServer/Controllers/UserController.cs
+++ b/TimesynqServer/Controllers/UserController.cs
@@ -30,7 +30,7 @@ namespace TimesynqServer.Controllers
             }
             Guid callerGuid = Guid.Parse(callerId);
 
-            TimesynqUser? user = await _userRepository.GetById(callerGuid);
+            TimesynqUser? user = await _userRepository.GetByIdAsync(callerGuid);
             if (user == null)
             {
                 return ErrorResponse(StatusCodes.Status404NotFound, "User not found");

--- a/TimesynqServer/Controllers/UserController.cs
+++ b/TimesynqServer/Controllers/UserController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using TimesynqServer.Database.Entities;
 using TimesynqServer.Extensions;
+using TimesynqServer.Models.DTO;
 using TimesynqServer.Services.Repository.UserRepository;
 
 namespace TimesynqServer.Controllers
@@ -21,6 +22,10 @@ namespace TimesynqServer.Controllers
 
         [HttpGet("me")]
         [Authorize]
+        [ProducesResponseType(typeof(ResponseDTO<UserDTO>), StatusCodes.Status200OK)]
+        [ProducesErrorResponseType(typeof(ResponseDTO<object>))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Me()
         {
             string? callerId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/TimesynqServer/Hubs/TrackerHub/TrackerHub.cs
+++ b/TimesynqServer/Hubs/TrackerHub/TrackerHub.cs
@@ -44,7 +44,7 @@ namespace TimesynqServer.Hubs.TrackerHub
             await _trackerHubCache.RemoveConnectionAsync(callerGuid, connection.RoomCode);
 
             string roomCode = connection.RoomCode;
-            TimesynqUser? user = await _userRepository.GetById(callerGuid);
+            TimesynqUser? user = await _userRepository.GetByIdAsync(callerGuid);
             if (user == null)
             {
                 return;
@@ -171,7 +171,7 @@ namespace TimesynqServer.Hubs.TrackerHub
 
             await Groups.AddToGroupAsync(Context.ConnectionId, roomCode);
 
-            TimesynqUser? user = await _userRepository.GetById(callerGuid);
+            TimesynqUser? user = await _userRepository.GetByIdAsync(callerGuid);
             if (user == null)
             {
                 return;

--- a/TimesynqServer/Middleware/EmailNotConfirmedMiddleware.cs
+++ b/TimesynqServer/Middleware/EmailNotConfirmedMiddleware.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
+using System.Text.Json;
+using TimesynqServer.Database.Entities;
+using TimesynqServer.Models.DTO;
+
+namespace TimesynqServer.Middleware
+{
+    public class EmailNotConfirmedMiddleware
+    {
+
+        private readonly RequestDelegate _next;
+
+        public EmailNotConfirmedMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context, UserManager<TimesynqUser> userManager)
+        {
+
+            ClaimsPrincipal user = context.User;
+
+            if(user?.Identity?.IsAuthenticated == false)
+            {
+                await _next(context);
+                return;
+            }
+
+            //we can use the null-forgiving operator as long as LogAuthorizedUserIdMiddleware is before EmailNotConfirmedMiddleware in the pipeline
+            string callerId = context.User.FindFirst(ClaimTypes.NameIdentifier)!.Value!;
+
+            TimesynqUser? timesynqUser = await userManager.FindByIdAsync(callerId);
+            if(timesynqUser?.EmailConfirmed == true)
+            {
+                await _next(context);
+                return;
+            }
+
+            Endpoint? endpoint = context.GetEndpoint();
+            IReadOnlyList<AuthorizeAttribute>? authorizeAttributes = endpoint?.Metadata.GetOrderedMetadata<AuthorizeAttribute>();
+
+            if(authorizeAttributes == null)
+            {
+                await _next(context);
+                return;
+            }
+
+            bool requiresConfirmedRole = authorizeAttributes
+                .Where(a => !string.IsNullOrEmpty(a.Roles))
+                .SelectMany(a => a.Roles!.Split(','))
+                .Select(r => r.Trim())
+                .Contains("ConfirmedUser", StringComparer.OrdinalIgnoreCase);
+
+            if (!requiresConfirmedRole)
+            {
+                await _next(context);
+                return;
+            }
+
+            var response = new ResponseDTO<object>
+            {
+                StatusCode = StatusCodes.Status403Forbidden,
+                Errors = ["Confirm your email to access this."],
+                Result = null,
+            };
+
+            string serializedResponse = JsonSerializer.Serialize(response);
+
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+
+            await context.Response.WriteAsync(serializedResponse);
+        }
+
+    }
+}

--- a/TimesynqServer/Middleware/ExceptionsMiddleware.cs
+++ b/TimesynqServer/Middleware/ExceptionsMiddleware.cs
@@ -36,7 +36,7 @@ namespace TimesynqServer.Middleware
                 string serializedResponse = JsonSerializer.Serialize(response);
 
                 context.Response.ContentType = "application/json";
-                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
 
                 await context.Response.WriteAsync(serializedResponse);
             }

--- a/TimesynqServer/Middleware/LogAuthorizedUserIdMiddleware.cs
+++ b/TimesynqServer/Middleware/LogAuthorizedUserIdMiddleware.cs
@@ -30,7 +30,8 @@ namespace TimesynqServer.Middleware
                     }
                     else
                     {
-                        _logger.LogInformation("User {UserId} called endpoint {Endpoint}", callerId, endpoint.DisplayName);
+                        string? role = context.User.FindFirst(ClaimTypes.Role)?.Value;
+                        _logger.LogInformation("User {UserId} with role {Role} called endpoint {Endpoint}", callerId, role, endpoint.DisplayName);
                     }
                 }
             }

--- a/TimesynqServer/Program.cs
+++ b/TimesynqServer/Program.cs
@@ -89,10 +89,12 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseAuthentication();
-app.UseAuthorization();
 
 app.UseMiddleware<ExceptionsMiddleware>();
 app.UseMiddleware<LogAuthorizedUserIdMiddleware>();
+app.UseMiddleware<EmailNotConfirmedMiddleware>();
+
+app.UseAuthorization();
 
 app.MapControllers();
 app.MapTimesynqIdentityApi<TimesynqUser>();

--- a/TimesynqServer/Services/Repository/FollowRepository/FollowRepository.cs
+++ b/TimesynqServer/Services/Repository/FollowRepository/FollowRepository.cs
@@ -19,6 +19,7 @@ namespace TimesynqServer.Services.Repository.FollowRepository
         public async Task<Follow?> GetFollowAsync(Guid followerId, Guid followeeId)
         {
             return await _dbContext.Follows
+                .AsNoTracking()
                 .Where(f => f.FollowerId == followerId && f.FolloweeId == followeeId)
                 .FirstOrDefaultAsync();
         }
@@ -26,6 +27,7 @@ namespace TimesynqServer.Services.Repository.FollowRepository
         public async Task<int> GetFollowersCountAsync(Guid followeeId)
         {
             return await _dbContext.Follows
+                .AsNoTracking()
                 .Where(f => f.FolloweeId == followeeId)
                 .CountAsync();
         }
@@ -33,6 +35,7 @@ namespace TimesynqServer.Services.Repository.FollowRepository
         public async Task<int> GetFolloweesCountAsync(Guid followerId)
         {
             return await _dbContext.Follows
+                .AsNoTracking()
                 .Where(f => f.FollowerId == followerId)
                 .CountAsync();
         }
@@ -40,22 +43,36 @@ namespace TimesynqServer.Services.Repository.FollowRepository
         public async Task<IEnumerable<UserDTO>> GetFollowersAsync(Guid followeeId, int pageNumber, int pageSize)
         {
             return await _dbContext.Follows
+                .AsNoTracking()
                 .Where(f => f.FolloweeId == followeeId)
-                .Include(f => f.Follower)
+                .OrderBy(f => f.CreatedOnUTC)
                 .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
-                .Select(f => f.Follower!.ToUserDTO())
+                .Select(f => new UserDTO
+                {
+                    Id = f.Follower!.Id,
+                    UserName = f.Follower.UserName!,
+                    ProfilePicture = f.Follower.ProfilePicture!,
+                    CreatedOnUTC = f.Follower.CreatedOnUTC,
+                })
                 .ToListAsync();
         }
 
         public async Task<IEnumerable<UserDTO>> GetFolloweesAsync(Guid followerId, int pageNumber, int pageSize)
         {
             return await _dbContext.Follows
+                .AsNoTracking()
                 .Where(f => f.FollowerId == followerId)
-                .Include(f => f.Followee)
+                .OrderBy(f => f.CreatedOnUTC)
                 .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
-                .Select(f => f.Followee!.ToUserDTO())
+                .Select(f => new UserDTO 
+                {
+                    Id = f.Followee!.Id,
+                    UserName = f.Followee.UserName!,
+                    ProfilePicture = f.Followee.ProfilePicture!,
+                    CreatedOnUTC = f.Followee.CreatedOnUTC,
+                })
                 .ToListAsync();
         }
 

--- a/TimesynqServer/Services/Repository/UserRepository/IUserRepository.cs
+++ b/TimesynqServer/Services/Repository/UserRepository/IUserRepository.cs
@@ -5,6 +5,6 @@ namespace TimesynqServer.Services.Repository.UserRepository
 {
     public interface IUserRepository
     {
-        public Task<TimesynqUser?> GetById(Guid userId);
+        public Task<TimesynqUser?> GetByIdAsync(Guid userId);
     }
 }

--- a/TimesynqServer/Services/Repository/UserRepository/UserRepository.cs
+++ b/TimesynqServer/Services/Repository/UserRepository/UserRepository.cs
@@ -1,4 +1,5 @@
-﻿using TimesynqServer.Database;
+﻿using Microsoft.AspNetCore.Identity;
+using TimesynqServer.Database;
 using TimesynqServer.Database.Entities;
 using TimesynqServer.Extensions;
 using TimesynqServer.Models.DTO;
@@ -8,23 +9,16 @@ namespace TimesynqServer.Services.Repository.UserRepository
     public class UserRepository : IUserRepository
     {
 
-        private readonly TimesynqDbContext _dbContext;
+        private readonly UserManager<TimesynqUser> _userManager;
 
-        public UserRepository(TimesynqDbContext dbContext)
+        public UserRepository(UserManager<TimesynqUser> userManager)
         {
-            _dbContext = dbContext;
+            _userManager = userManager;
         }
 
-        public async Task<TimesynqUser?> GetById(Guid userId)
+        public async Task<TimesynqUser?> GetByIdAsync(Guid userId)
         {
-            TimesynqUser? user = await _dbContext.Users.FindAsync(userId);
-
-            if (user == null)
-            {
-                return null;
-            }
-
-            return user;
+            return await _userManager.FindByIdAsync(userId.ToString());
         }
     }
 }


### PR DESCRIPTION
various api improvements:
- EmailNotConfirmedMiddleware notifies authenticated but unconfirmed users that they need to verify their email to access role protected endpoints (previously returned 404 as per the default Identity behavior)
- Add AsNoTracking to readonly queries, OrderBy for consistent paging, and proper column filtering
- ProducesResponseType attributes that detail response schema in swagger

Closes #30 
Closes #29 
Closes #26 