### PR TITLE
make references to id values consistent

### DIFF
--- a/TimesynqServer.Infrastructure/Extensions/IdentityApiEndpointRouteBuilderExtensions.cs
+++ b/TimesynqServer.Infrastructure/Extensions/IdentityApiEndpointRouteBuilderExtensions.cs
@@ -161,10 +161,10 @@ public static class IdentityApiEndpointRouteBuilderExtensions
         });
 
         routeGroup.MapGet("/confirmEmail", async Task<Results<ContentHttpResult, UnauthorizedHttpResult>>
-            ([FromQuery] string userId, [FromQuery] string code, [FromQuery] string? changedEmail, [FromServices] IServiceProvider sp) =>
+            ([FromQuery] string userIdString, [FromQuery] string code, [FromQuery] string? changedEmail, [FromServices] IServiceProvider sp) =>
         {
             var userManager = sp.GetRequiredService<UserManager<TUser>>();
-            if (await userManager.FindByIdAsync(userId) is not { } user)
+            if (await userManager.FindByIdAsync(userIdString) is not { } user)
             {
                 // We could respond with a 404 instead of a 401 like Identity UI, but that feels like unnecessary information.
                 return TypedResults.Unauthorized();
@@ -425,10 +425,10 @@ public static class IdentityApiEndpointRouteBuilderExtensions
                 : await userManager.GenerateEmailConfirmationTokenAsync(user);
             code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
 
-            var userId = await userManager.GetUserIdAsync(user);
+            var userIdString = await userManager.GetUserIdAsync(user);
             var routeValues = new RouteValueDictionary()
             {
-                ["userId"] = userId,
+                ["userId"] = userIdString,
                 ["code"] = code,
             };
 

--- a/TimesynqServer/Controllers/AuthorizedController.cs
+++ b/TimesynqServer/Controllers/AuthorizedController.cs
@@ -6,7 +6,7 @@ namespace TimesynqServer.Controllers
     [ApiController]
     public class AuthorizedController : ControllerBase
     {
-        public Guid CallerGuid => Guid.Parse(
+        public Guid CallerId => Guid.Parse(
             User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? throw new InvalidOperationException("Caller ID is missing.")
         );
     }

--- a/TimesynqServer/Controllers/FollowController.cs
+++ b/TimesynqServer/Controllers/FollowController.cs
@@ -25,9 +25,9 @@ namespace TimesynqServer.Controllers
         [ProducesErrorResponseType(typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> GetFollow(Guid followeeGuid)
+        public async Task<IActionResult> GetFollow(Guid followeeId)
         {
-            Result<FollowDTO> getFollowResult = await _followService.GetFollowAsync(CallerGuid, followeeGuid);
+            Result<FollowDTO> getFollowResult = await _followService.GetFollowAsync(CallerId, followeeId);
             return getFollowResult.Match
             (
                 onSuccess: Ok,
@@ -64,12 +64,12 @@ namespace TimesynqServer.Controllers
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> FollowUser([FromBody] FollowRequestDTO followRequest)
         {
-            Result<FollowDTO> followResult = await _followService.FollowAsync(CallerGuid, followRequest.FolloweeGuid);
+            Result<FollowDTO> followResult = await _followService.FollowAsync(CallerId, followRequest.FolloweeId);
             return followResult.Match
             (
                 onSuccess: followDTO =>
                 {
-                    string resourceUri = $"{Request.Scheme}://{Request.Host}{Request.Path}{followRequest.FolloweeGuid}";
+                    string resourceUri = $"{Request.Scheme}://{Request.Host}{Request.Path}{followRequest.FolloweeId}";
                     return Created(resourceUri, followDTO);
                 },
                 onFailure: error => Problem(
@@ -88,7 +88,7 @@ namespace TimesynqServer.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> UnfollowUser([FromBody] UnfollowRequestDTO unfollowRequest)
         {
-            Result unfollowResult = await _followService.UnfollowAsync(CallerGuid, unfollowRequest.FolloweeGuid);
+            Result unfollowResult = await _followService.UnfollowAsync(CallerId, unfollowRequest.FolloweeId);
             return unfollowResult.Match<IActionResult>
             (
                 onSuccess: NoContent,

--- a/TimesynqServer/Controllers/UserController.cs
+++ b/TimesynqServer/Controllers/UserController.cs
@@ -25,7 +25,7 @@ namespace TimesynqServer.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Me()
         {
-            UserDTO? userDTO = await _userService.GetUserAsync(CallerGuid);
+            UserDTO? userDTO = await _userService.GetUserAsync(CallerId);
             if (userDTO == null)
             {
                 return Problem(

--- a/TimesynqServer/DTO/Request/Follow/FollowRequestDTO.cs
+++ b/TimesynqServer/DTO/Request/Follow/FollowRequestDTO.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// The ID of the user who is being followed.
         /// </summary>
-        public required Guid FolloweeGuid { get; init; }
+        public required Guid FolloweeId { get; init; }
     }
 }

--- a/TimesynqServer/DTO/Request/Follow/UnfollowRequestDTO.cs
+++ b/TimesynqServer/DTO/Request/Follow/UnfollowRequestDTO.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// The ID of the user who is being followed.
         /// </summary>
-        public required Guid FolloweeGuid { get; init; }
+        public required Guid FolloweeId { get; init; }
     }
 }

--- a/TimesynqServer/Hubs/TrackerHub/TrackerHub.cs
+++ b/TimesynqServer/Hubs/TrackerHub/TrackerHub.cs
@@ -32,17 +32,17 @@ namespace TimesynqServer.Hubs.TrackerHub
                 return;
             }
 
-            Guid callerGuid = Guid.Parse(Context.UserIdentifier);
+            Guid callerId = Guid.Parse(Context.UserIdentifier);
 
-            Connection? connection = await _trackerHubCache.GetConnectionAsync(callerGuid);
+            Connection? connection = await _trackerHubCache.GetConnectionAsync(callerId);
             if (connection == null)
             {
                 return;
             }
-            await _trackerHubCache.RemoveConnectionAsync(callerGuid, connection.RoomCode);
+            await _trackerHubCache.RemoveConnectionAsync(callerId, connection.RoomCode);
 
             string roomCode = connection.RoomCode;
-            UserDTO? userDTO = await _userService.GetUserAsync(callerGuid);
+            UserDTO? userDTO = await _userService.GetUserAsync(callerId);
             if (userDTO == null)
             {
                 return;
@@ -59,7 +59,7 @@ namespace TimesynqServer.Hubs.TrackerHub
             //if the user that disconnected is the owner of a room, wait 30s before closing the room
             await Task.Delay(30 * 1000);
 
-            Connection? ownerConnection = await _trackerHubCache.GetConnectionAsync(callerGuid, roomCode);
+            Connection? ownerConnection = await _trackerHubCache.GetConnectionAsync(callerId, roomCode);
             if (ownerConnection != null)
             {
                 return;
@@ -81,9 +81,9 @@ namespace TimesynqServer.Hubs.TrackerHub
                 return;
             }
 
-            Guid callerGuid = Guid.Parse(Context.UserIdentifier);
+            Guid callerId = Guid.Parse(Context.UserIdentifier);
 
-            Room? ownedRoom = await _trackerHubCache.GetRoomAsync(roomCode, callerGuid);
+            Room? ownedRoom = await _trackerHubCache.GetRoomAsync(roomCode, callerId);
             if (ownedRoom == null)
             {
                 return;
@@ -106,9 +106,9 @@ namespace TimesynqServer.Hubs.TrackerHub
                 return;
             }
 
-            Guid callerGuid = Guid.Parse(Context.UserIdentifier);
+            Guid callerId = Guid.Parse(Context.UserIdentifier);
 
-            Connection? existingConnection = await _trackerHubCache.GetConnectionAsync(callerGuid);
+            Connection? existingConnection = await _trackerHubCache.GetConnectionAsync(callerId);
             if (existingConnection != null)
             {
                 return;
@@ -123,7 +123,7 @@ namespace TimesynqServer.Hubs.TrackerHub
             var newRoom = new Room
             {
                 RoomCode = roomCode,
-                OwnerId = callerGuid,
+                OwnerId = callerId,
             };
 
             bool isRoomCached = await _trackerHubCache.SetRoomAsync(roomCode, newRoom);
@@ -147,9 +147,9 @@ namespace TimesynqServer.Hubs.TrackerHub
                 return;
             }
 
-            Guid callerGuid = Guid.Parse(Context.UserIdentifier);
+            Guid callerId = Guid.Parse(Context.UserIdentifier);
 
-            Connection? existingConnection = await _trackerHubCache.GetConnectionAsync(callerGuid);
+            Connection? existingConnection = await _trackerHubCache.GetConnectionAsync(callerId);
             if (existingConnection != null)
             {
                 return;
@@ -159,10 +159,10 @@ namespace TimesynqServer.Hubs.TrackerHub
             {
                 ConnectionId = Context.ConnectionId,
                 RoomCode = roomCode,
-                UserId = callerGuid,
+                UserId = callerId,
             };
 
-            bool isConnectionCached = await _trackerHubCache.SetConnectionAsync(callerGuid, newConnection);
+            bool isConnectionCached = await _trackerHubCache.SetConnectionAsync(callerId, newConnection);
             if (!isConnectionCached)
             {
                 return;
@@ -170,7 +170,7 @@ namespace TimesynqServer.Hubs.TrackerHub
 
             await Groups.AddToGroupAsync(Context.ConnectionId, roomCode);
 
-            UserDTO? userDTO = await _userService.GetUserAsync(callerGuid);
+            UserDTO? userDTO = await _userService.GetUserAsync(callerId);
             if (userDTO == null)
             {
                 return;

--- a/TimesynqServer/Middleware/EmailNotConfirmedMiddleware.cs
+++ b/TimesynqServer/Middleware/EmailNotConfirmedMiddleware.cs
@@ -27,9 +27,9 @@ namespace TimesynqServer.Middleware
             }
 
             //we can use the null-forgiving operator as long as LogAuthorizedUserIdMiddleware is before EmailNotConfirmedMiddleware in the pipeline
-            string callerId = context.User.FindFirst(ClaimTypes.NameIdentifier)!.Value!;
+            string callerIdString = context.User.FindFirst(ClaimTypes.NameIdentifier)!.Value!;
 
-            bool isEmailConfirmed = await userService.IsUserConfirmed(Guid.Parse(callerId));
+            bool isEmailConfirmed = await userService.IsUserConfirmed(Guid.Parse(callerIdString));
             if (isEmailConfirmed)
             {
                 await _next(context);

--- a/TimesynqServer/Middleware/LogAuthorizedUserIdMiddleware.cs
+++ b/TimesynqServer/Middleware/LogAuthorizedUserIdMiddleware.cs
@@ -23,15 +23,15 @@ namespace TimesynqServer.Middleware
                 IAuthorizeData? authorizeData = endpoint.Metadata.GetMetadata<IAuthorizeData>();
                 if (authorizeData != null)
                 {
-                    string? callerId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-                    if (callerId.IsNullOrEmpty())
+                    string? callerIdString = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                    if (callerIdString.IsNullOrEmpty())
                     {
                         _logger.LogWarning("User with missing name identifier called endpoint {Endpoint}", endpoint.DisplayName);
                     }
                     else
                     {
                         string? role = context.User.FindFirst(ClaimTypes.Role)?.Value;
-                        _logger.LogInformation("User {UserId} with role {Role} called endpoint {Endpoint}", callerId, role, endpoint.DisplayName);
+                        _logger.LogInformation("User {UserId} with role {Role} called endpoint {Endpoint}", callerIdString, role, endpoint.DisplayName);
                     }
                 }
             }


### PR DESCRIPTION
if an id value is of type string it will be referred to as "objectIdString" for variables or "ObjectIdString" for fields
if an id value is of type guid it will be referred to as "objectId" for variables or "ObjectId" for fields

the only (known) exception to this is SignalR ConnectionId, which is a string

Closes #34 