### PR TITLE
add support for .net aspire

### DIFF
--- a/TimesynqServer.AppHost/AppHost.cs
+++ b/TimesynqServer.AppHost/AppHost.cs
@@ -1,0 +1,16 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+IResourceBuilder<SqlServerDatabaseResource> database = builder.AddSqlServer("database")
+    .WithDataVolume()
+    .AddDatabase("timesynq-db");
+
+IResourceBuilder<RedisResource> redis = builder.AddRedis("redis")
+    .WithRedisInsight();
+
+builder.AddProject<Projects.TimesynqServer>("timesynqserver")
+    .WithReference(database)
+    .WaitFor(database)
+    .WithReference(redis)
+    .WaitFor(redis);
+
+builder.Build().Run();

--- a/TimesynqServer.AppHost/Properties/launchSettings.json
+++ b/TimesynqServer.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17255;http://localhost:15089",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21231",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22215"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15089",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19260",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20192"
+      }
+    }
+  }
+}

--- a/TimesynqServer.AppHost/TimesynqServer.AppHost.csproj
+++ b/TimesynqServer.AppHost/TimesynqServer.AppHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.1" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>be597091-7ec0-4a11-915a-1e65017f8d1d</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="9.4.1" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TimesynqServer\TimesynqServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TimesynqServer.Infrastructure/DependencyInjection.cs
+++ b/TimesynqServer.Infrastructure/DependencyInjection.cs
@@ -32,7 +32,6 @@ namespace TimesynqServer.Infrastructure
 
         public static IServiceCollection AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddLogging(configuration);
             services.AddDatabase(configuration);
             services.AddAuth();
 
@@ -76,7 +75,7 @@ namespace TimesynqServer.Infrastructure
 
         public static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration)
         {
-            string? dbConnectionString = configuration.GetConnectionString("SqlServerDatabase");
+            string? dbConnectionString = configuration.GetConnectionString("timesynq-db");
             services.AddDbContext<TimesynqDbContext>(options => options.UseSqlServer(dbConnectionString, b => b.MigrationsAssembly("TimesynqServer.Persistence")));
             return services;
         }

--- a/TimesynqServer.Infrastructure/DependencyInjection.cs
+++ b/TimesynqServer.Infrastructure/DependencyInjection.cs
@@ -32,7 +32,26 @@ namespace TimesynqServer.Infrastructure
 
         public static IServiceCollection AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
         {
+            services.AddLogging(configuration);
+            services.AddDatabase(configuration);
+            services.AddAuth();
 
+            services.AddTransient<IEmailSender<TimesynqUser>, EmailSender<TimesynqUser>>();
+
+            services.AddDefaultAWSOptions(configuration.GetAWSOptions());
+            services.AddAWSService<IAmazonSimpleEmailService>();
+            services.Configure<EmailSenderOptions>(configuration.GetSection(EmailSenderOptions.ConfigurationSection));
+
+            services.AddSignalR();
+
+            services.AddScoped<IUserService, UserService>();
+            services.AddScoped<IFollowService, FollowService>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddLogging(this IServiceCollection services, IConfiguration configuration)
+        {
             SerilogOptions serilogOptions = configuration.GetSection(SerilogOptions.ConfigurationSection).Get<SerilogOptions>()!;
             Log.Logger = new LoggerConfiguration()
                 .Enrich.FromLogContext()
@@ -52,13 +71,20 @@ namespace TimesynqServer.Infrastructure
                 .CreateLogger();
 
             services.AddSerilog();
+            return services;
+        }
 
+        public static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration)
+        {
+            string? dbConnectionString = configuration.GetConnectionString("SqlServerDatabase");
+            services.AddDbContext<TimesynqDbContext>(options => options.UseSqlServer(dbConnectionString, b => b.MigrationsAssembly("TimesynqServer.Persistence")));
+            return services;
+        }
+
+        public static IServiceCollection AddAuth(this IServiceCollection services)
+        {
             services.AddAuthorization();
             services.AddAuthentication().AddCookie(IdentityConstants.ApplicationScheme);
-
-            string? dbConnectionString = configuration.GetConnectionString("SqlServerDatabase");
-
-            services.AddDbContext<TimesynqDbContext>(options => options.UseSqlServer(dbConnectionString, b => b.MigrationsAssembly("TimesynqServer.Persistence")));
 
             services.AddIdentityCore<TimesynqUser>(options =>
             {
@@ -75,17 +101,6 @@ namespace TimesynqServer.Infrastructure
                 .AddUserStore<UserStore<TimesynqUser, TimesynqRole, TimesynqDbContext, Guid>>()
                 .AddErrorDescriber<CustomIdentityErrorDescriber>()
                 .AddApiEndpoints();
-
-            services.AddTransient<IEmailSender<TimesynqUser>, EmailSender<TimesynqUser>>();
-
-            services.AddDefaultAWSOptions(configuration.GetAWSOptions());
-            services.AddAWSService<IAmazonSimpleEmailService>();
-            services.Configure<EmailSenderOptions>(configuration.GetSection(EmailSenderOptions.ConfigurationSection));
-
-            services.AddSignalR();
-
-            services.AddScoped<IUserService, UserService>();
-            services.AddScoped<IFollowService, FollowService>();
 
             return services;
         }

--- a/TimesynqServer.Infrastructure/Extensions/IdentityApiEndpointRouteBuilderExtensions.cs
+++ b/TimesynqServer.Infrastructure/Extensions/IdentityApiEndpointRouteBuilderExtensions.cs
@@ -153,10 +153,10 @@ public static class IdentityApiEndpointRouteBuilderExtensions
         });
 
         routeGroup.MapGet("/confirmEmail", async Task<Results<ContentHttpResult, UnauthorizedHttpResult>>
-            ([FromQuery] string userIdString, [FromQuery] string code, [FromQuery] string? changedEmail, [FromServices] IServiceProvider sp) =>
+            ([FromQuery] string userId, [FromQuery] string code, [FromQuery] string? changedEmail, [FromServices] IServiceProvider sp) =>
         {
             var userManager = sp.GetRequiredService<UserManager<TUser>>();
-            if (await userManager.FindByIdAsync(userIdString) is not { } user)
+            if (await userManager.FindByIdAsync(userId) is not { } user)
             {
                 // We could respond with a 404 instead of a 401 like Identity UI, but that feels like unnecessary information.
                 return TypedResults.Unauthorized();
@@ -417,10 +417,10 @@ public static class IdentityApiEndpointRouteBuilderExtensions
                 : await userManager.GenerateEmailConfirmationTokenAsync(user);
             code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
 
-            var userIdString = await userManager.GetUserIdAsync(user);
+            var userId = await userManager.GetUserIdAsync(user);
             var routeValues = new RouteValueDictionary()
             {
-                ["userId"] = userIdString,
+                ["userId"] = userId,
                 ["code"] = code,
             };
 

--- a/TimesynqServer.ServiceDefaults/Extensions.cs
+++ b/TimesynqServer.ServiceDefaults/Extensions.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation(tracing =>
+                        // Exclude health check requests from tracing
+                        tracing.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
+                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+                    )
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks(HealthEndpointPath);
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/TimesynqServer.ServiceDefaults/TimesynqServer.ServiceDefaults.csproj
+++ b/TimesynqServer.ServiceDefaults/TimesynqServer.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/TimesynqServer.sln
+++ b/TimesynqServer.sln
@@ -17,6 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimesynqServer.Infrastructu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimesynqServer.Contracts", "TimesynqServer.Contracts\TimesynqServer.Contracts.csproj", "{A1DB426A-9421-4A10-ABBB-6CEEFF1A3AFC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimesynqServer.AppHost", "TimesynqServer.AppHost\TimesynqServer.AppHost.csproj", "{BBCF7402-7E81-44FF-A15A-834F04AEECC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimesynqServer.ServiceDefaults", "TimesynqServer.ServiceDefaults\TimesynqServer.ServiceDefaults.csproj", "{063ABAA7-4588-CEEF-057C-A2A0BCF87E77}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +55,14 @@ Global
 		{A1DB426A-9421-4A10-ABBB-6CEEFF1A3AFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1DB426A-9421-4A10-ABBB-6CEEFF1A3AFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1DB426A-9421-4A10-ABBB-6CEEFF1A3AFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBCF7402-7E81-44FF-A15A-834F04AEECC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBCF7402-7E81-44FF-A15A-834F04AEECC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBCF7402-7E81-44FF-A15A-834F04AEECC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBCF7402-7E81-44FF-A15A-834F04AEECC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{063ABAA7-4588-CEEF-057C-A2A0BCF87E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{063ABAA7-4588-CEEF-057C-A2A0BCF87E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{063ABAA7-4588-CEEF-057C-A2A0BCF87E77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{063ABAA7-4588-CEEF-057C-A2A0BCF87E77}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TimesynqServer/Middleware/ExceptionsMiddleware.cs
+++ b/TimesynqServer/Middleware/ExceptionsMiddleware.cs
@@ -58,7 +58,7 @@ namespace TimesynqServer.Middleware
 
                 var problemDetails = problemDetailsFactory.CreateProblemDetails(
                     httpContext: context,
-                    statusCode: StatusCodes.Status401Unauthorized,
+                    statusCode: StatusCodes.Status500InternalServerError,
                     title: "Invalid Operation",
                     type: "https://datatracker.ietf.org/doc/html/rfc7235#section-3.1",
                     detail: "Invalid operation."

--- a/TimesynqServer/Program.cs
+++ b/TimesynqServer/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using StackExchange.Redis;
 using TimesynqServer.Application;
 using TimesynqServer.Extensions;
 using TimesynqServer.Hubs.TrackerHub;
@@ -10,6 +11,8 @@ using TimesynqServer.Persistence;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Logging.ClearProviders();
+
+builder.AddServiceDefaults();
 
 builder.Services.AddPersistenceServices();
 builder.AddInfrastructure();
@@ -47,6 +50,8 @@ builder.Services.AddCors(p => p.AddPolicy(DevCorsPolicy, builder =>
 
 var app = builder.Build();
 
+app.MapDefaultEndpoints();
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -76,6 +81,13 @@ app.MapGet("ping", (ILogger<Program> logger) =>
 {
     logger.LogInformation("pong");
     return "pong";
+});
+
+app.MapPost("redis", async (IConnectionMultiplexer redis) =>
+{
+    IDatabase db = redis.GetDatabase();
+    await db.StringSetAsync("testkey", "testvalue");
+    return "success";
 });
 
 app.Run();

--- a/TimesynqServer/TimesynqServer.csproj
+++ b/TimesynqServer/TimesynqServer.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\TimesynqServer.Contracts\TimesynqServer.Contracts.csproj" />
     <ProjectReference Include="..\TimesynqServer.Infrastructure\TimesynqServer.Infrastructure.csproj" />
     <ProjectReference Include="..\TimesynqServer.Persistence\TimesynqServer.Persistence.csproj" />
+    <ProjectReference Include="..\TimesynqServer.ServiceDefaults\TimesynqServer.ServiceDefaults.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
adds .net aspire, wires up sql server + database, redis + redis insights. extension methods for adding serilog are still in the infrastructure assembly, but are unused since aspire comes with its own structured logging

Closes #10 