### PR TITLE
change identicon from string to uint

### DIFF
--- a/TimesynqServer.Application/DTO/UserDTO.cs
+++ b/TimesynqServer.Application/DTO/UserDTO.cs
@@ -19,19 +19,20 @@ namespace TimesynqServer.Application.DTO
         public string UserName { get; }
 
         /// <summary>
-        /// A 21 character string representing an identicon.
-        /// First 6 chars = hex color;
-        /// Next 15 = 5x5 grid (binary), mirrored:
-        /// Cols 1=5, 2=4. '1' = color, '0' = white.
+        /// An unsigned 32 bit integer, which encodes an identicon
+        /// Bit 0 is ignored.
+        /// Bit 1-15 = 5x5 grid (binary), mirroed:
+        /// Bits 16 - 31 encodes an RGB565 color
+        /// The bits for the color are read in reverse since it's more convenient that way and the order is not relevant
         /// </summary>
-        public string ProfilePicture { get; }
+        public uint ProfilePicture { get; }
 
         /// <summary>
         /// The date when the user registered their account.
         /// </summary>
         public DateTime CreatedOnUTC { get; }
 
-        private UserDTO(Guid id, string userName, string profilePicture, DateTime createdOnUTC)
+        private UserDTO(Guid id, string userName, uint profilePicture, DateTime createdOnUTC)
         {
             Id = id;
             UserName = userName;

--- a/TimesynqServer.Common/TimesynqRandomizer.cs
+++ b/TimesynqServer.Common/TimesynqRandomizer.cs
@@ -9,39 +9,24 @@ namespace TimesynqServer.Common
     {
         private static readonly Random _random = new();
 
-        private const int _pixelsLength = 15;
-        private const string _pixelVals = "00111";
-
         private const int _randomCodeLength = 8;
         private const string _characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
 
         /// <summary>
-        /// Generates a unique, 21 character identicon string consisting of a hex color code followed by a series of pixel values.
+        /// Generates a random unsigned 32 bit integer, which encodes an identicon.
         /// </summary>
         /// <remarks>
-        /// First 6 chars = hex color;
-        /// Next 15 = 5x5 grid (binary), mirrored:
-        /// Cols 1=5, 2=4. '1' = color, '0' = white.
+        /// Bit 0 is ignored.
+        /// Bit 1-15 = 5x5 grid (binary), mirroed:
+        /// Bits 16 - 31 encodes an RGB565 color
+        /// The bits for the color are read in reverse since it's more convenient that way and the order is not relevant
         /// </remarks>
         /// <returns>
-        /// A string containing a 6-character hexadecimal color code, followed by a sequence of characters representing the identicon's pixels.
+        /// An unsigned 32 bit integer in the range 1,000,000,000 and 4,294,967,295 
         /// </returns>
-        public static string GenerateIdenticon()
+        public static uint GenerateIdenticon()
         {
-            var sb = new StringBuilder();
-
-            string color = string.Format("{0:X6}", _random.Next(0x1000000));
-            sb.Append(color);
-
-            var identiconPixels = new char[_pixelsLength];
-            for (int i = 0; i < _pixelsLength; i++)
-            {
-                int randomIndex = _random.Next(_pixelVals.Length);
-                identiconPixels[i] = _pixelVals[randomIndex];
-            }
-            sb.Append(new string(identiconPixels));
-
-            return sb.ToString();
+            return (uint)_random.NextInt64(1000000000, uint.MaxValue);
         }
 
         /// <summary>

--- a/TimesynqServer.Contracts/Projections/UserProjection.cs
+++ b/TimesynqServer.Contracts/Projections/UserProjection.cs
@@ -16,12 +16,13 @@
         public string UserName { get; }
 
         /// <summary>
-        /// A 21 character string representing an identicon.
-        /// First 6 chars = hex color;
-        /// Next 15 = 5x5 grid (binary), mirrored:
-        /// Cols 1=5, 2=4. '1' = color, '0' = white.
+        /// An unsigned 32 bit integer, which encodes an identicon
+        /// Bit 0 is ignored.
+        /// Bit 1-15 = 5x5 grid (binary), mirroed:
+        /// Bits 16 - 31 encodes an RGB565 color
+        /// The bits for the color are read in reverse since it's more convenient that way and the order is not relevant
         /// </summary>
-        public string ProfilePicture { get; }
+        public uint ProfilePicture { get; }
 
         /// <summary>
         /// The date when the user registered their account.
@@ -33,9 +34,9 @@
         /// </summary>
         /// <param name="id">The unique identifier of the user.</param>
         /// <param name="userName">The user's unique username.</param>
-        /// <param name="profilePicture">A 21 character string representing an identicon.</param>
+        /// <param name="profilePicture">An unsigned 32 bit integer, which encodes an identicon.</param>
         /// <param name="createdOnUTC">The date when the user registered their account.</param>
-        public UserProjection(Guid id, string userName, string profilePicture, DateTime createdOnUTC)
+        public UserProjection(Guid id, string userName, uint profilePicture, DateTime createdOnUTC)
         {
             Id = id;
             UserName = userName;

--- a/TimesynqServer.Domain/Entities/Users/TimesynqUser.cs
+++ b/TimesynqServer.Domain/Entities/Users/TimesynqUser.cs
@@ -31,12 +31,13 @@ namespace TimesynqServer.Domain.Entities.Users
         public string NormalizedSavedUserName { get; private set; } = string.Empty;
 
         /// <summary>
-        /// A 21 character string representing an identicon.
-        /// First 6 chars = hex color;
-        /// Next 15 = 5x5 grid (binary), mirrored:
-        /// Cols 1=5, 2=4. '1' = color, '0' = white.
+        /// An unsigned 32 bit integer, which encodes an identicon
+        /// Bit 0 is ignored.
+        /// Bit 1-15 = 5x5 grid (binary), mirroed:
+        /// Bits 16 - 31 encodes an RGB565 color
+        /// The bits for the color are read in reverse since it's more convenient that way and the order is not relevant
         /// </summary>
-        public string ProfilePicture { get; } = TimesynqRandomizer.GenerateIdenticon();
+        public uint ProfilePicture { get; } = TimesynqRandomizer.GenerateIdenticon();
 
         /// <summary>
         /// The date when the user registered their account.

--- a/TimesynqServer.Persistence/Migrations/20250831052438_Identicon.Designer.cs
+++ b/TimesynqServer.Persistence/Migrations/20250831052438_Identicon.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TimesynqServer.Persistence;
 
@@ -11,9 +12,11 @@ using TimesynqServer.Persistence;
 namespace TimesynqServer.Migrations
 {
     [DbContext(typeof(TimesynqDbContext))]
-    partial class TimesynqDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250831052438_Identicon")]
+    partial class Identicon
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TimesynqServer.Persistence/Migrations/20250831052438_Identicon.cs
+++ b/TimesynqServer.Persistence/Migrations/20250831052438_Identicon.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TimesynqServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class Identicon : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "ProfilePicture",
+                table: "AspNetUsers",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePicture",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+        }
+    }
+}


### PR DESCRIPTION
changes the way identicons are represented.
the new implementation is definitely better in terms of space efficiency, but i doubt it will really matter. storing and decoding the string is a little more straightforward now though